### PR TITLE
Update wikipathways-data-release to work on any server

### DIFF
--- a/data-release/README.md
+++ b/data-release/README.md
@@ -1,0 +1,24 @@
+# WikiPathways Data Release
+
+## Associated repos
+
+- https://github.com/wikipathways/java-bots
+- https://github.com/wikipathways/scripts
+
+We talk about this content in the following issue:
+https://github.com/wikipathways/GPML2RDF/issues/57
+
+## To run a monthly WikiPathways Data Release
+
+```
+cd /data/projects/wikipathways-data/public_html
+<fill-in-the-path>/wikipathways-data-release "$(pwd)" > >(tee out.log) 2> >(tee err.log >&2)
+```
+
+or
+
+```
+<fill-in-the-path>/wikipathways-data-release "/data/projects/wikipathways-data/public_html" > >(tee out.log) 2> >(tee err.log >&2)
+```
+
+The directory `/data/projects/wikipathways-data/public_html` is an existing directory on wikipathways-data.toolforge.org, and it's intended to hold the WikiPathways release data. On the blade server, the analogous directory is at `/var/www/wikipathways-data`.

--- a/data-release/index.php
+++ b/data-release/index.php
@@ -1,0 +1,140 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>WikiPathways Data</title>
+  <link rel="stylesheet" href="../../.style.css">
+  <script src="../../.sorttable.js"></script>
+</head>
+
+<body>
+
+  <div id="container">
+  
+    <h1>WikiPathways Data Downloads</h1>
+    
+    <table class="sortable">
+      <thead>
+        <tr>
+          <th>Filename</th>
+          <th>Type</th>
+          <th>Size <small>(bytes)</small></th>
+          <th>Date Modified</th>
+        </tr>
+      </thead>
+      <tbody>
+      <?php
+        // Opens directory
+        $myDirectory=opendir(".");
+        
+        // Gets each entry
+        while($entryName=readdir($myDirectory)) {
+          $dirArray[]=$entryName;
+        }
+        
+        // Finds extensions of files
+        function findexts ($filename) {
+          $filename=strtolower($filename);
+          $exts=preg_split("/[/\\.]/", $filename);
+          $n=count($exts)-1;
+          $exts=$exts[$n];
+          return $exts;
+        }
+        
+        // Closes directory
+        closedir($myDirectory);
+        
+        // Counts elements in array
+        $indexCount=count($dirArray);
+        
+        // Sorts files
+        sort($dirArray);
+        
+        // Loops through the array of files
+        for($index=0; $index < $indexCount; $index++) {
+        
+          // Allows ./?hidden to show hidden files
+          if($_SERVER['QUERY_STRING']=="hidden")
+          {$hide="";
+          $ahref="./";
+          $atext="Hide";}
+          else
+          {$hide=".";
+          $ahref="./?hidden";
+          $atext="Show";}
+          if(substr("$dirArray[$index]", 0, 1) != $hide) {
+          
+          // Gets File Names
+          $name=$dirArray[$index];
+          $namehref=$dirArray[$index];
+          
+          // Gets Extensions 
+          $extn=findexts($dirArray[$index]); 
+          
+          // Gets file size 
+          $size=number_format(filesize($dirArray[$index]));
+          
+          // Gets Date Modified Data
+          $modtime=date("M j Y g:i A", filemtime($dirArray[$index]));
+          $timekey=date("YmdHis", filemtime($dirArray[$index]));
+          
+          // Prettifies File Types, add more to suit your needs.
+          switch ($extn){
+            case "png": $extn="PNG Image"; break;
+            case "jpg": $extn="JPEG Image"; break;
+            case "svg": $extn="SVG Image"; break;
+            case "gif": $extn="GIF Image"; break;
+            case "ico": $extn="Windows Icon"; break;
+            
+            case "txt": $extn="Text File"; break;
+            case "log": $extn="Log File"; break;
+            case "htm": $extn="HTML File"; break;
+            case "php": $extn="PHP Script"; break;
+            case "js": $extn="Javascript"; break;
+            case "css": $extn="Stylesheet"; break;
+            case "pdf": $extn="PDF Document"; break;
+            
+            case "zip": $extn="ZIP Archive"; break;
+	    case "tgz": $extn="TGZ Archive"; break;
+	    case "gmt": $extn="Gene Matrix Transposed"; break;
+            case "bak": $extn="Backup File"; break;
+            
+            default: $extn=strtoupper($extn)." File"; break;
+          }
+          
+          // Separates directories
+          if(is_dir($dirArray[$index])) {
+            $extn="&lt;Directory&gt;"; 
+            $size="&lt;Directory&gt;"; 
+            $class="dir";
+          } else {
+            $class="file";
+          }
+          
+          // Cleans up . and .. directories 
+          if($name=="."){$name=". (Current Directory)"; $extn="&lt;System Dir&gt;";}
+          if($name==".."){$name=".. (Parent Directory)"; $extn="&lt;System Dir&gt;";}
+          
+          // Print 'em
+          print("
+          <tr class='$class'>
+            <td><a href='./$namehref'>$name</a></td>
+            <td><a href='./$namehref'>$extn</a></td>
+            <td><a href='./$namehref'>$size</a></td>
+            <td sorttable_customkey='$timekey'><a href='./$namehref'>$modtime</a></td>
+          </tr>");
+          }
+        }
+      ?>
+      </tbody>
+    </table>
+  
+   <!-- <h2><?php print("<a href='$ahref'>$atext hidden files</a>"); ?></h2>
+    -->
+	<h2><a href="../">Parent directory</a></h2>
+  </div>
+  
+</body>
+
+</html>

--- a/data-release/wikipathways-data-release
+++ b/data-release/wikipathways-data-release
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###
 # Run this script monthly in order to prepare and organize a regularly released set of curated content
@@ -15,14 +15,24 @@
 # The script also stashes a copy of the lucene index into an index subdirectory 
 ###
 
-DATA='/var/www/wikipathways-data' 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# Based on http://linuxcommand.org/lc3_wss0140.php
+# and https://codeinthehole.com/tips/bash-error-reporting/
+PROGNAME=$(basename "$0")
+
+DATA="$1"
+if [ ! -d "$DATA" ]; then
+  echo "$PROGNAME: error: $DATA is not a directory" >&2
+  exit 1
+fi
 DATE=`date +%Y%m%d`
 URL_BASE='https://wikipathways.org/wpi/batchDownload.php' 
 
 ## setup dir
 mkdir "$DATA"/"$DATE"
-if ! cp "$DATA"/.index.php.master "$DATA"/"$DATE"/.index.php; then
-        echo "ERROR: Can't copy .index.php to new date dir" >&2
+if ! cp "$SCRIPT_DIR"/index.php "$DATA"/"$DATE"/.index.php; then
+        echo "ERROR: Can't copy index.php to new date dir" >&2
 fi
 
 # tag to collect
@@ -39,8 +49,8 @@ for h in "${TYPES[@]}"
 do
         DIR="$DATA"/"$DATE"/"$h"
 	mkdir "$DIR"
-        if ! cp "$DATA"/.index.php.master "$DIR"/.index.php; then
-                echo "ERROR: Can't copy .index.php.master to new data dir for $h" >&2
+        if ! cp "$SCRIPT_DIR"/index.php "$DIR"/.index.php; then
+                echo "ERROR: Can't copy index.php to new data dir for $h" >&2
         fi
 done
 
@@ -92,11 +102,12 @@ done
 # now stash index files
 IN_DIR="$DATA"/"$DATE"/index
 mkdir "$IN_DIR"
-if ! cp "$DATA"/.index.php.master "$IN_DIR"/.index.php; then
-	echo "ERROR: Can't copy .index.php to new index dir" >&2
+if ! cp "$SCRIPT_DIR"/index.php "$IN_DIR"/.index.php; then
+	echo "ERROR: Can't copy index.php to new index dir" >&2
 fi
 
 #############
+# Database
 # DO NOT MAKE PUBLIC DUMPS OF WP DB; IT CONTAINS USER ACCOUNT INFO
 #############
 #BKUP_DIR='/home/wikipathways/backup'
@@ -107,23 +118,33 @@ fi
 #	echo "ERROR: Can't copy sql file" >&2
 #fi 
 
-INDEX_DIR='/home/wikipathways/wp-indexer-main/index/'
-INDEX_FILE=wikipathways-"$DATE"-index.tgz
-if ! tar -zcf "$INDEX_FILE" "$INDEX_DIR"; then
-	echo "ERROR: Can't tar gzip index" >&2
-fi
-if ! mv "$INDEX_FILE" "$IN_DIR"/.; then
-	echo "ERROR: Can't move $INDEX_FILE" >&2
-fi
+################
+# Lucene Indexer
+################
+## TODO: the following doesn't work
+#INDEX_DIR='/home/wikipathways/wp-indexer-main/index/'
+#INDEX_FILE=wikipathways-"$DATE"-index.tgz
+#if ! tar -zcf "$INDEX_FILE" "$INDEX_DIR"; then
+#	echo "ERROR: Can't tar gzip index" >&2
+#fi
+#if ! mv "$INDEX_FILE" "$IN_DIR"/.; then
+#	echo "ERROR: Can't move $INDEX_FILE" >&2
+#fi
 
+########################
 # now retrieve GMT files
+########################
+
+# TODO: these files are not released every day. If they haven't been released
+# today, the gmt directory won't have any gmt files. Should we address this?
+
 DATE2=`date +%Y%m%d`
 GMT_URL="http://data.wikipathways.org/java-bots/gmt/$DATE2"
 echo $GMT_URL
 GMT_DIR="$DATA"/"$DATE"/gmt
 mkdir "$GMT_DIR"
-if ! cp "$DATA"/.index.php.master "$GMT_DIR"/.index.php; then
-        echo "ERROR: Can't copy .index.php.master to new gmt dir" >&2
+if ! cp "$SCRIPT_DIR"/index.php "$GMT_DIR"/.index.php; then
+        echo "ERROR: Can't copy index.php to new gmt dir" >&2
 fi
 
 for i in "${ORGS[@]}"
@@ -138,11 +159,13 @@ done
 
 find "$GMT_DIR" -size 0 -print0|xargs -0 rm
 
+#####################
 # now get RDF release
+#####################
 RDF_DIR="$DATA"/"$DATE"/rdf
 mkdir "$RDF_DIR"
-if ! cp "$DATA"/.index.php.master "$RDF_DIR"/.index.php; then
-        echo "ERROR: Can't copy .index.php.master to new rdf dir" >&2
+if ! cp "$SCRIPT_DIR"/index.php "$RDF_DIR"/.index.php; then
+        echo "ERROR: Can't copy index.php to new rdf dir" >&2
 fi
 
 OUT="$RDF_DIR"/wikipathways-"$DATE"-rdf-gpml.zip
@@ -160,36 +183,29 @@ if ! wget --no-check-certificate https://jenkins.bigcat.unimaas.nl/job/WikiPathw
         echo "ERROR: Can't get file" >&2
 fi
 
-# remake current dir with symlinks and special index.php for gpmls
-CUR_DIR="$DATA"/current
-rm -r "$CUR_DIR"
-mkdir "$CUR_DIR"
-if ! cp "$DATA"/.index.php.master "$CUR_DIR"/.index.php; then
-        echo "ERROR: Can't copy .index.php.master to new current dir" >&2
+###############################################################
+# create symlink "./current" pointing to latest dated directory
+###############################################################
+
+# a relative symlink means the data directory will still work if copied
+PREV_DIR="$(pwd)"
+cd "$DATA"
+
+CUR_DIR=current
+
+# if it's a symlink, delete it
+if [ -h "$CUR_DIR" ]; then
+  rm "$CUR_DIR"
+
+# if exists but isn't a symlink, throw an error b/c this is unexpected
+elif [ -e "$CUR_DIR" ]; then
+  echo "$PROGNAME: error: $(pwd)/$CUR_DIR exists but isn't a symlink" >&2
+  # To unavoid anything unexpected, go back to previous directory
+  cd "$PREV_DIR"
+  exit 1
 fi
 
-ln -s "$DATA"/"$DATE"/gmt "$CUR_DIR"/gmt
-ln -s "$DATA"/"$DATE"/index "$CUR_DIR"/index
-ln -s "$DATA"/"$DATE"/rdf "$CUR_DIR"/rdf
-ln -s "$DATA"/"$DATE"/svg "$CUR_DIR"/svg
+ln -s "$DATE" "$CUR_DIR"
 
-## SIMPLE CURRENT GPML DIR
-ln -s "$DATA"/"$DATE"/gpml "$CUR_DIR"/gpml
-
-## COMPLEX CURRENT GPML DIR: special hrefs and symlinks
-#mkdir "$CUR_DIR"/gpml
-#if ! cp "$DATA"/.index.php.gpml-master "$CUR_DIR"/gpml/.index.php; then
-#        echo "ERROR: Can't copy .index.php.gpml-master to new current gpml dir" >&2
-#fi
-## update index.php to enable generic links to date-specific file
-#sed -i "s/\$releaseDate\=\"[0-9]\+\"\;/\$releaseDate\=\"$DATE\"\;/" "$CUR_DIR"/gpml/.index.php
-#
-#for i in "${ORGS[@]}"
-#do
-#	GS=${i// /_} # replace space character with _ in species name 
-#	SOURCE="$DATA"/"$DATE"/gpml/wikipathways-"$DATE"-gpml-"$GS".zip
-#	TARGET="$DATA"/current/gpml/wikipathways-current-gpml-"$GS".zip
-#	ln -s "$SOURCE" "$TARGET"
-#done
-
-#done!
+# To unavoid anything unexpected, go back to previous directory
+cd "$PREV_DIR"


### PR DESCRIPTION
These updates allow the wikipathways-data-release script to work on any server. The major/breaking changes:
* require an argument to specify a data directory instead of just hard-coding `/var/www/wikipathways-data`
* include the index.php file instead of assuming it exists at `"$DATA"/.index.php.master`

The minor changes:
* make wikipathways-data-release executable
* add README.md for documentation
* remove unused code